### PR TITLE
Protect nightlies and PR actions from running when no VMs are provisionable

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,14 +18,17 @@ jobs:
     steps:
     - name: Checkout Source
       uses: actions/checkout@v2
+      if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
       uses: actions/setup-ruby@v1
+      if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
         ruby-version: "2.7"
 
     - name: Cache gems
       uses: actions/cache@v2
+      if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
         path: vendor/gems
         key: ${{ runner.os }}-nightly-${{ hashFiles('**/Gemfile') }}
@@ -34,6 +37,7 @@ jobs:
           ${{ runner.os }}-
 
     - name: Install gems
+      if: ${{ github.repository_owner == 'puppetlabs' }}
       run: |
         bundle config path vendor/gems
         bundle config jobs 8
@@ -43,7 +47,17 @@ jobs:
 
     - name: Setup Acceptance Test Matrix
       id: get-matrix
+      if: ${{ github.repository_owner == 'puppetlabs' }}
       run: "bundle exec matrix_from_metadata"
+
+    - name: Setup Acceptance Test Matrix
+      id: get-matrix
+      run: |
+        if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
+          bundle exec matrix_from_metadata
+        else
+          echo  "::set-output name=matrix::{}"
+        fi
 
   Acceptance:
     needs:

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -16,14 +16,17 @@ jobs:
     steps:
     - name: Checkout Source
       uses: actions/checkout@v2
+      if: ${{ github.repository_owner == 'puppetlabs' }}
 
     - name: Activate Ruby 2.7
       uses: actions/setup-ruby@v1
+      if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
         ruby-version: "2.7"
 
     - name: Cache gems
       uses: actions/cache@v2
+      if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
         path: vendor/gems
         key: ${{ runner.os }}-pr-${{ hashFiles('**/Gemfile') }}
@@ -32,6 +35,7 @@ jobs:
           ${{ runner.os }}-
 
     - name: Install gems
+      if: ${{ github.repository_owner == 'puppetlabs' }}
       run: |
         bundle config path vendor/gems
         bundle config jobs 8
@@ -41,7 +45,12 @@ jobs:
 
     - name: Setup Acceptance Test Matrix
       id: get-matrix
-      run: "bundle exec matrix_from_metadata"
+      run: |
+        if [ '${{ github.repository_owner }}' == 'puppetlabs' ]; then
+          bundle exec matrix_from_metadata
+        else
+          echo  "::set-output name=matrix::{}"
+        fi
 
   Acceptance:
     needs:


### PR DESCRIPTION
This change resolves the last part of https://github.com/puppetlabs/provision_service/issues/187 : not running nightly tests on non-puppetlabs forks.

[Example of the changes](https://github.com/DavidS/puppetlabs-testing/runs/1423538743?check_suite_focus=true) for a PR running on a non-puppetlabs repo: https://github.com/DavidS/puppetlabs-testing/pull/1/checks?check_run_id=1423558912#step:6:2

This fixes the last task on https://github.com/puppetlabs/provision_service/issues/187