### PR TITLE
pdksync - Dropping Support for Debian 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,6 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
-        "9",
         "10"
       ]
     },


### PR DESCRIPTION
Dropping Support for Debian 9
pdk version: `2.1.0` 
