### PR TITLE
(maint) - Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,16 +21,15 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7",
         "8"
@@ -39,30 +38,31 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
-        "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11",
         "12",
         "15"
       ]
@@ -70,19 +70,17 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04",
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "2008 R2",
-        "2012 R2",
         "2016",
         "2019",
+        "2022",
         "10"
       ]
     }
@@ -90,7 +88,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.10 < 7.0.0"
+      "version_requirement": ">= 6.24.0 < 8.0.0"
     }
   ],
   "description": "This module is a testing only module derived from puppetlabs-motd",


### PR DESCRIPTION
Prior to this PR, metadata.json included Os's no longer supported by puppet agent.
Additionally, it did not include certain OS' that our supported modules are tested against or puppet 7.
As this repo is used for provision testing, it is important that we can test the provisioning of VMs with these OS's.