### PR TITLE
(maint) - Remove forced provision service provisioning

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       run: |
-        bundle exec matrix_from_metadata_v2 --provision-service
+        bundle exec matrix_from_metadata_v2
 
   Acceptance:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"

--- a/.github/workflows/repo_dispatch.yml
+++ b/.github/workflows/repo_dispatch.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Acceptance Test Matrix
       id: get-matrix
       run: |
-        bundle exec matrix_from_metadata_v2 --provision-service
+        bundle exec matrix_from_metadata_v2
 
   Acceptance:
     name: "${{matrix.platforms.label}}, ${{matrix.collection}}"


### PR DESCRIPTION
its not necessary to spin up 30+ vms to test the provision service, the regular number will suffice